### PR TITLE
add missing package for build geoserver container

### DIFF
--- a/docker/geoserver/Dockerfile
+++ b/docker/geoserver/Dockerfile
@@ -10,6 +10,7 @@ ENV GEOSERVER_DATA_DIR="/geoserver_data/data"
 #
 # Download and install GeoServer
 #
+RUN apt update && apt install wget -y && apt install unzip -y
 RUN cd /usr/local/tomcat/webapps \
     && wget --no-check-certificate --progress=bar:force:noscroll https://artifacts.geonode.org/geoserver/${GEOSERVER_VERSION}/geoserver.war -O geoserver.war \
     && unzip -q geoserver.war -d geoserver \


### PR DESCRIPTION
The docker-compose build is raising issues on the geoserver container since looks like those two packages are no longer automatically available.
We have to declare them into the Dockerfile